### PR TITLE
Section 4 - Écran moyen: Diminution de max-width pour décoller des bords

### DIFF
--- a/script/scss/_ecranmoyen.scss
+++ b/script/scss/_ecranmoyen.scss
@@ -1,3 +1,14 @@
+// SECTION 4
+@media screen and (max-width: 1280px) and (min-width: 768px) {
+    .section4_card--text {
+        max-width: 90%;
+
+        p {
+            font-size: 1.2rem;
+        }
+    }
+}
+
 @media screen and (max-width: 992px) {
     .section5_conteneur {
         flex-direction: column-reverse;

--- a/style/css/script.css
+++ b/style/css/script.css
@@ -637,6 +637,14 @@ a {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
+@media screen and (max-width: 1280px) and (min-width: 768px) {
+  .section4_card--text {
+    max-width: 90%;
+  }
+  .section4_card--text p {
+    font-size: 1.2rem;
+  }
+}
 @media screen and (max-width: 992px) {
   .section5_conteneur {
     flex-direction: column-reverse;


### PR DESCRIPTION
Max-width à 90% pcq sinon le texte et les images 
Rapetisser la taille de la police sont trop près de la bordure de l'écran.
Diminuer la taille de la police.

***** Mais je semble avoir fait une gaffe: le code n'est pas là ??
J'ose pas le remettre...
Je les ferai après qu'on est fusionné les autres branches.

Le code qui devait être là:

// SECTION 4
@media screen and (max-width: 1280px) and (min-width: 768px) {
    .section4_card--text {
        max-width: 90%;

        p {
            font-size: 1.2rem;
        }
    }
}