### PR TITLE
Footer: Augmenter le point de rupture à 992px -> ecranmoyen

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,7 +319,7 @@
             </div>
         </div>
         <div class="footer_flex">
-            <div>
+            <div class="footer_flex--attribution">
                 <p>Cégep de Trois-Rivières</p>
                 <p>Site réalisé par Nathalie Fellis et Jonathan Claes</p>
             </div>

--- a/script/scss/_ecranmoyen.scss
+++ b/script/scss/_ecranmoyen.scss
@@ -83,7 +83,27 @@
     }
 
 
-    
+    // FOOTER
 
+    .footer_flex{
+        flex-direction: column;
+        align-items: center;
+
+        &--attribution {
+            text-align: center;
+            width: 100%;
+            margin: 5% 0;
+        }
+    }
+    
+    .footer_contact{
+        width: 100%;
+        text-align: center;
+        margin: 2% 0;
+    }
+    
+    p{
+        font-size: 1rem;
+    }
     
 }

--- a/script/scss/_ecranpetit.scss
+++ b/script/scss/_ecranpetit.scss
@@ -116,21 +116,4 @@
     .section4_card--column {
         flex-direction: column;
     }
-
-    // FOOTER
-
-    .footer_flex{
-        flex-direction: column;
-        align-items: center;
-    }
-
-    .footer_contact{
-        width: 100%;
-        text-align: center;
-        margin: 5% 0;
-    }
-
-    p{
-        font-size: 1rem;
-    }
 }

--- a/script/scss/_footer.scss
+++ b/script/scss/_footer.scss
@@ -1,24 +1,22 @@
-.footer_section1 {
-
-    padding-top: 2rem;
+footer{
+    padding-top: 2rem ;
     align-items: center;
     max-width: 1200px;
     width: 100%;
     display: flex;
     flex-direction: column;
-    margin: auto;
+    margin:auto;
     justify-content: center;
     border-top: 4px solid $color-accent;
     margin-top: 6%;
-
 }
 
-.footer_logo {
+.footer_logo{
     align-items: center;
     justify-content: center;
 }
 
-.footer_flex {
+.footer_flex{
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;

--- a/style/css/script.css
+++ b/style/css/script.css
@@ -581,7 +581,7 @@ a {
   z-index: -1; /* Mettre la bande sous la grille */
 }
 
-.footer_section1 {
+footer {
   padding-top: 2rem;
   align-items: center;
   max-width: 1200px;
@@ -714,6 +714,23 @@ a {
   .section6_img6 {
     grid-column: 2/4;
   }
+  .footer_flex {
+    flex-direction: column;
+    align-items: center;
+  }
+  .footer_flex--attribution {
+    text-align: center;
+    width: 100%;
+    margin: 5% 0;
+  }
+  .footer_contact {
+    width: 100%;
+    text-align: center;
+    margin: 2% 0;
+  }
+  p {
+    font-size: 1rem;
+  }
 }
 @media screen and (max-width: 767px) {
   #section_hero {
@@ -804,17 +821,5 @@ a {
   }
   .section4_card--column {
     flex-direction: column;
-  }
-  .footer_flex {
-    flex-direction: column;
-    align-items: center;
-  }
-  .footer_contact {
-    width: 100%;
-    text-align: center;
-    margin: 5% 0;
-  }
-  p {
-    font-size: 1rem;
   }
 }


### PR DESCRIPTION
Le footer devenait encombré à partir de 992px, j'ai déplacé le style écran petit dans écran moyen.
J'ai aussi ajouté la classe footer_flex--attribution pour centrer le texte.